### PR TITLE
Update name engineering weekly

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,22 +8,22 @@ In this repository, you will find listing of all meetings, notes, and events.
 
 ## Engineering Weekly 
 
-In the Engineering Weekly meeting, the core engineering team, contributors, and casual followers check in to discuss the weekly progress of the project, to call attention to particular items, to make announcements, or to seek discussion of a topic.
+In the *Engineering Weekly* meetings, the core engineering team, contributors, and casual followers check in to discuss the progress of the project, to call attention to particular items, to make announcements, or to seek discussion of a topic.
 
-Everyone Is Welcome! Check details below.
+**Everyone Is Welcome! Check details below.**
 
-** When:** Every Thursday, 8am  
-** Time zone:** [Denver, CO](https://www.timeanddate.com/worldclock/usa/denver)  
-** Link:** [https://zoom.us/j/874817645](https://zoom.us/j/874817645)  
-** Length:** 30 minutes.  
+**When:** Every Thursday, 8am  
+**Time zone:** [Denver, CO](https://www.timeanddate.com/worldclock/usa/denver)  
+**Link:** [https://zoom.us/j/874817645](https://zoom.us/j/874817645)  
+**Length:** 30 minutes.  
 
-#### Agenda
+### Agenda
 
 You can find the agenda of the next meeting in the [open issues section](https://github.com/MARKETProtocol/community/issues) of this repository. The issue is named according to the respective calendar week.
 
-You can also propose the addition of itens to the agenda using the comments within the same issue.
+You can also propose the discussion of relavant topics using the comments within the same issue.
 
-#### How to join  
+### How to join  
 
 We use [Zoom](https://zoom.us/download) for our meeting calls. This allows us to stream directly to YouTube and to have calls with more than 25 users. Zoom may require a download before you are able to join. If you click on a Zoom link to a meeting room, it will automatically suggest the software to download.
 
@@ -37,7 +37,7 @@ US: +1 646 558 8656 or +1 669 900 6833 or +1 408 638 0968
 Meeting ID: 874 817 645  
 International numbers available. [Check here.](https://zoom.us/u/S7u4IVa9)  
 
-#### Notes from previous meetings
+### Notes from previous meetings
 
 You can find the [notes from previous meetings here](https://github.com/MARKETProtocol/community/tree/master/meeting-notes).
 

--- a/README.md
+++ b/README.md
@@ -4,32 +4,45 @@ MARKET Protocol has been created to provide a secure, flexible, open source foun
 
 # Community
 
-In this repository, you isting of all community meetings, notes, and events.
+In this repository, you will find listing of all meetings, notes, and events.
 
-## Community Devs Meeting
+## Engineering Weekly 
 
-**When:** Every MoThnday, 5pm UTC.
-**Link:** [https://zoom.us/j/874817645](https://zoom.us/j/874817645)
-**Length:** 60 minutes.
+In the Engineering Weekly meeting, the core engineering team, contributors, and casual followers check in to discuss the weekly progress of the project, to call attention to particular items, to make announcements, or to seek discussion of a topic.
 
-#### How to join the meetings
+Everyone Is Welcome! Check details below.
 
-We use [Zoom](https://zoom.us/) for our community calls. This allows us to stream directly to YouTube and to have calls with more than 25 users. Zoom may require a download before you are able to join. If you click on a Zoom link to a meeting room, it will automatically suggest the software to download. Please, let us know if you have any issues with Zoom.
+** When:** Every Thursday, 8am  
+** Time zone:** [Denver, CO](https://www.timeanddate.com/worldclock/usa/denver)  
+** Link:** [https://zoom.us/j/874817645](https://zoom.us/j/874817645)  
+** Length:** 60 minutes.  
+
+#### Agenda
+
+You can find the agenda of the next meeting in the [open issues section](https://github.com/MARKETProtocol/community/issues) of this repository. The issue is named according to the respective calendar week.
+
+You can also propose the addition of itens to the agenda using the comments within the same issue.
+
+#### How to join  
+
+We use [Zoom](https://zoom.us/download) for our meeting calls. This allows us to stream directly to YouTube and to have calls with more than 25 users. Zoom may require a download before you are able to join. If you click on a Zoom link to a meeting room, it will automatically suggest the software to download.
 
 You can use Zoom on PC, Mac, Linux, iOS and Android.
 
-Or iPhone one-tap :
-US: +16465588656,,874817645# or +16699006833,,874817645#
-Or Telephone:
-Dial(for higher quality, dial a number based on your current location):
-US: +1 646 558 8656 or +1 669 900 6833 or +1 408 638 0968
-Meeting ID: 874 817 645
-International numbers available: [https://zoom.us/u/S7u4IVa9](https://zoom.us/u/S7u4IVa9)
+Or iPhone one-tap:     
+US: +16465588656,,874817645# or +16699006833,,874817645#  
+Or Telephone:  
+Dial (for higher quality, dial a number based on your current location):  
+US: +1 646 558 8656 or +1 669 900 6833 or +1 408 638 0968  
+Meeting ID: 874 817 645  
+International numbers available. [Check here.](https://zoom.us/u/S7u4IVa9)  
 
-#### Notes from the past meetings
+#### Notes from previous meetings
 
-You can find the [notes from the past meetings [here](https://github.com/MARKETProtocol/community/tree/master/meeting-notes).
+You can find the [notes from previous meetings here](https://github.com/MARKETProtocol/community/tree/master/meeting-notes).
 
 ## Contribute
 
 Join our [Discord Community](https://www.marketprotocol.io/discord) to interact with members of our dev staff and other contributors.
+
+[![contributions welcome](https://img.shields.io/badge/contributions-welcome-brightgreen.svg?style=flat)](https://github.com/dwyl/esta/issues)

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Everyone Is Welcome! Check details below.
 ** When:** Every Thursday, 8am  
 ** Time zone:** [Denver, CO](https://www.timeanddate.com/worldclock/usa/denver)  
 ** Link:** [https://zoom.us/j/874817645](https://zoom.us/j/874817645)  
-** Length:** 60 minutes.  
+** Length:** 30 minutes.  
 
 #### Agenda
 

--- a/README.md
+++ b/README.md
@@ -4,8 +4,32 @@ MARKET Protocol has been created to provide a secure, flexible, open source foun
 
 # Community
 
-Listing of all community meetings, notes, and events.
+In this repository, you isting of all community meetings, notes, and events.
 
-You can find the [notes from past meetings here](https://github.com/MARKETProtocol/community/tree/master/meeting-notes). 
+## Community Devs Meeting
+
+**When:** Every MoThnday, 5pm UTC.
+**Link:** [https://zoom.us/j/874817645](https://zoom.us/j/874817645)
+**Length:** 60 minutes.
+
+#### How to join the meetings
+
+We use [Zoom](https://zoom.us/) for our community calls. This allows us to stream directly to YouTube and to have calls with more than 25 users. Zoom may require a download before you are able to join. If you click on a Zoom link to a meeting room, it will automatically suggest the software to download. Please, let us know if you have any issues with Zoom.
+
+You can use Zoom on PC, Mac, Linux, iOS and Android.
+
+Or iPhone one-tap :
+US: +16465588656,,874817645# or +16699006833,,874817645#
+Or Telephone:
+Dial(for higher quality, dial a number based on your current location):
+US: +1 646 558 8656 or +1 669 900 6833 or +1 408 638 0968
+Meeting ID: 874 817 645
+International numbers available: [https://zoom.us/u/S7u4IVa9](https://zoom.us/u/S7u4IVa9)
+
+#### Notes from the past meetings
+
+You can find the [notes from the past meetings [here](https://github.com/MARKETProtocol/community/tree/master/meeting-notes).
+
+## Contribute
 
 Join our [Discord Community](https://www.marketprotocol.io/discord) to interact with members of our dev staff and other contributors.

--- a/helpers/template-ew-notes.md
+++ b/helpers/template-ew-notes.md
@@ -1,4 +1,4 @@
-# Community Meeting cw #NN
+# Engineering Weekly cw #NN
 ## Month DD YYYY
 ### [Agenda]()
 ### [Recording]()

--- a/meeting-notes/180412-cw15-ew-notes.md
+++ b/meeting-notes/180412-cw15-ew-notes.md
@@ -1,4 +1,4 @@
-# Community Meeting cw #15
+# Engineering Weekly cw #15
 ## April 12 2018
 ## Notes
 * Introductions

--- a/meeting-notes/180419-cw16-ew-notes.md
+++ b/meeting-notes/180419-cw16-ew-notes.md
@@ -1,4 +1,4 @@
-# Community Meeting cw #16
+# Engineering Weekly cw #16
 ## April 19 2018
 ## Notes
 * Introductions

--- a/meeting-notes/180426-cw17-cm-notes.md
+++ b/meeting-notes/180426-cw17-cm-notes.md
@@ -1,18 +1,7 @@
 # Community Meeting cw #17
-## April 26 2018
+## April 19 2018, [8:00 AM MDT](https://www.worldtimebuddy.com/?qm=1&lid=7&h=7&date=2018-4-26&sln=8-9)
+### [Agenda](https://github.com/MARKETProtocol/community/issues/2)
+### [Recording]()
+### Attendees
+## To-do
 ## Notes
-* Introductions
-  * Anyone new on the call
-* Update on status
-  * dApp release
-  * Backend environment (for static site and dApp beta deployment)
-  * Contribution resources - discussing using slate (see origin protocol for eg)
-* Major commits this week
-  * @nitinrgupta - new static site
-  * @perfectmak - added more testing!!
-* Next major Milestones
-* Contributors - how can we help you? Issues? suggestions?
-* What we need help with
-  * Static site
-  * dApp deployment
- 

--- a/meeting-notes/180426-cw17-ew-notes.md
+++ b/meeting-notes/180426-cw17-ew-notes.md
@@ -1,4 +1,4 @@
-# Community Meeting cw #17
+# Engineering Weekly cw #17
 ## April 19 2018, [8:00 AM MDT](https://www.worldtimebuddy.com/?qm=1&lid=7&h=7&date=2018-4-26&sln=8-9)
 ### [Agenda](https://github.com/MARKETProtocol/community/issues/2)
 ### [Recording]()


### PR DESCRIPTION
Update the previous docs to incorporate the new dev meeting name: Engineering Weekly.

Note: changes here depend on #3 and #5 